### PR TITLE
Fixed typo in archon.inc.php

### DIFF
--- a/packages/core/lib/archon.inc.php
+++ b/packages/core/lib/archon.inc.php
@@ -3482,7 +3482,7 @@ abstract class Core_Archon
       if($RepositoryID)
       {
          $repository = New Repository($RepositoryID);
-         $repsository->dbLoad();
+         $repository->dbLoad();
       }
       else
       {


### PR DESCRIPTION
A typo in a function call was causing a php fatal error.
