### PR TITLE
Fix to Contact Us forms

### DIFF
--- a/packages/collections/pub/research.php
+++ b/packages/collections/pub/research.php
@@ -539,11 +539,17 @@ function research_exec()
    elseif($_REQUEST['f'] == 'sendemails')
    {
       $arrDetails = $_ARCHON->Security->Session->ResearchCart->getCartDetailsArray();
-      foreach($arrDetails as $RepositoryID => $details)
+      if(!empty($arrDetails))
       {
-         $_ARCHON->sendEmail($_REQUEST['fromaddress'], $_REQUEST['message'], $_REQUEST['referer'], $_REQUEST['fromname'], $_REQUEST['subject'], $_REQUEST['fromphone'], $_REQUEST['details'] . '\n\n' . $details, $_REQUEST['detailsfunction'], $_REQUEST['detailsparams'], $RepositoryID);
+      	foreach($arrDetails as $RepositoryID => $details)
+      	{
+         	$_ARCHON->sendEmail($_REQUEST['fromaddress'], $_REQUEST['message'], $_REQUEST['referer'], $_REQUEST['fromname'], $_REQUEST['subject'], $_REQUEST['fromphone'], $_REQUEST['details'] . '\n\n' . $details, $_REQUEST['detailsfunction'], $_REQUEST['detailsparams'], $RepositoryID);
+      	}
       }
-
+      else
+      {
+      $_ARCHON->sendEmail($_REQUEST['fromaddress'], $_REQUEST['message'], $_REQUEST['referer'], $_REQUEST['fromname'], $_REQUEST['subject'], $_REQUEST['fromphone'], $_REQUEST['details'], $_REQUEST['detailsfunction'], $_REQUEST['detailsparams']);
+      }
       if(!$_ARCHON->Error)
       {
          $msg = "Thank you! Your e-mail has been sent.";


### PR DESCRIPTION
This fix checks if $arrDetails is !empty to avoid passing an empty array if there are no items in the cart.  If not, it follows the original foreach statement.  If it is empty, it calls sendEmail directly, without passing any RepositoryID information.
