### PR TITLE
Limit the updateResearchCartLinks javascript to themed pages

### DIFF
--- a/packages/collections/pub/findingaid.php
+++ b/packages/collections/pub/findingaid.php
@@ -89,7 +89,7 @@ if(!$_ARCHON->Error)
       flush();
    }
 
-   if(!$_ARCHON->Security->userHasAdministrativeAccess())
+   if(!$_ARCHON->Security->userHasAdministrativeAccess() && $_REQUEST['disabletheme'] !== '1')
    {
       ?>
       <script type="text/javascript">


### PR DESCRIPTION
The updateResearchCartLinks javascript should not be included on pages that have no theme, as there are no research cart links to update. This is very important for the Public EAD List page in particular, as the exported xml files should not have javascript inserted above the root element since it causes parsing and rendering errors. 

I've added the disabletheme request to the condition check for inserting that javascript function call.
