### PR TITLE
Direct Blob Extraction

### DIFF
--- a/packages/core/templates/default/digitalfileblob.inc.php
+++ b/packages/core/templates/default/digitalfileblob.inc.php
@@ -21,8 +21,9 @@ if ($_ARCHON->Security->Session->verifysession($session)){
            // echo print_r(base64_encode($arrfileblob[0]['FileContents']));
                     if (isset($arrfileblob)){
                         $arrfileblob =array_values($arrfileblob);
-                        $arrfileblob[0]['FileContents']=base64_encode($arrfileblob[0]['FileContents']);
-                       echo json_encode(array_values($arrfileblob));
+                       // $arrfileblob[0]['FileContents']=base64_encode($arrfileblob[0]['FileContents']);
+                       //echo json_encode(array_values($arrfileblob));
+                        echo print $arrfileblob[0]['FileContents'];
                     }
                     else {
 


### PR DESCRIPTION
Removed json encoded base 64 encoded blob.
Replaced with direct binary output.
