### PR TITLE
Retrieve up to 1m accessions

### DIFF
--- a/packages/core/templates/default/accession-list.inc.php
+++ b/packages/core/templates/default/accession-list.inc.php
@@ -13,7 +13,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 
                 $SearchFlags = $in_SearchFlags ? $in_SearchFlags : SEARCH_ACCESSIONS;
 
-                $arrAccessions = $_ARCHON->searchAccessions('', $SearchFlags, 0, $objCollection->ID);
+                $arrAccessions = $_ARCHON->searchAccessions('', $SearchFlags, 0, $objCollection->ID, 0, 0, 1000000, 0);
                 
 				header('HTTP/1.0 200 Created');
 								


### PR DESCRIPTION
During an ArchivesSpace migration we noticed that only the first
100 accessions were being retrieved due to the default search limit.

Setting the mysql limit to a very high value (1m) is a rough but ready
solution for grabbing all accessions (at LYRASIS we've never seen
Archon instances with accession counts anywhere near that number
 -- counts are generally in the hundreds to low thousands).

-- I'm not at all sure how this might potentially impact "regular" Archon 
users if at all, but it's the stopgap we used to workaround the migration 
issue.