### PR TITLE
Applied the following command

### DIFF
--- a/themes/aall/pdfsearch.inc.php
+++ b/themes/aall/pdfsearch.inc.php
@@ -6,7 +6,7 @@ isset($_ARCHON) or die();
 <div id='themeindex' class='bground'>
    <h1><label for="q">PDF/Deep Search</label></h1>
    <div id='pdfinput'>
-      <form name="form1" action="http://www.google.com/search" class="search">
+      <form name="form1" action="https://www.google.com/search" class="search">
          <input type="hidden" name="hq" value="inurl:www.library.illinois.edu/archives/alasfa intext:85/1/" />
          <input type="hidden" name="safe" value="off" />
          <input type="hidden" name="filter" value="0" />

--- a/themes/ala/pdfsearch.inc.php
+++ b/themes/ala/pdfsearch.inc.php
@@ -6,7 +6,7 @@ isset($_ARCHON) or die();
 <div id='themeindex' class='bground'>
    <h1><label for="q">PDF/Deep Search</label></h1>
    <div id='pdfinput'>
-      <form name="form1" action="http://www.google.com/search" class="search">
+      <form name="form1" action="https://www.google.com/search" class="search">
          <input type="hidden" name="hq" value="inurl:www.library.illinois.edu/archives/alasfa" />
          <input type="hidden" name="safe" value="off" />
          <input type="hidden" name="filter" value="0" />

--- a/themes/illinois/pdfsearch.inc.php
+++ b/themes/illinois/pdfsearch.inc.php
@@ -11,7 +11,7 @@ isset($_ARCHON) or die();
 <div style="width:40%; margin:1em auto; padding:1em; background-color:#F9F9FA; border:#ddd 1px solid; font-size:small" class="bground">
 <h2 style='margin-top:.1em'><label for="q">PDF/Deep Search</label></h2>
 <div style='text-align:center'>				
-    <form name="form1" action="http://www.google.com/search" class="search">
+    <form name="form1" action="https://www.google.com/search" class="search">
     <input type="hidden" name="hq" value="inurl:www.library.illinois.edu/archives/uasfa" />
     <input type="hidden" name="safe" value="off" />
     <input type="hidden" name="filter" value="0" />

--- a/themes/library_web/pdfsearch.inc.php
+++ b/themes/library_web/pdfsearch.inc.php
@@ -11,7 +11,7 @@ isset($_ARCHON) or die();
 <div style="width:40%; margin:1em auto; padding:1em; background-color:#F9F9FA; border:#ddd 1px solid; font-size:small" class="bground">
 <h2 style='margin-top:.1em'><label for="q">PDF/Deep Search</label></h2>
 <div style='text-align:center'>				
-    <form name="form1" action="http://www.google.com/search" class="search">
+    <form name="form1" action="https://www.google.com/search" class="search">
     <input type="hidden" name="hq" value="inurl:www.library.illinois.edu/archives/uasfa" />
     <input type="hidden" name="safe" value="off" />
     <input type="hidden" name="filter" value="0" />


### PR DESCRIPTION
grep -lir "http://www.google.com/search" * | xargs sed -i -e 's/http:\/\/www.google.com\/search/https:\/\/www.google.com\/search/g'

UIU had complaints on our Archon instance where Google was warning about people submitting information over an non-secure channel.  Most likely source of it was the forms where the action was set to http://www.google.com/search.

Warnings:
 * I didn't check to see if there were other on-https urls  being used in forms

 * Wasn't able to replicate the initial issue and have not yet verified
with user this fixes it.
Possible it's due to either chrome version OR some sort of different
trust settings.