### PR TITLE
Add MSSQL UTF-8 support to Archon & address an SQL injection vulnerability in the finding aid

### DIFF
--- a/_dev/resources/exportphrases.php
+++ b/_dev/resources/exportphrases.php
@@ -59,7 +59,11 @@ else if(!$_ARCHON->db->Login)
 if($_ARCHON->db->ServerType == 'MSSQL')
 {
    // these are necessary to prevent freetds from truncating large fields
-   putenv("TDSVER=70");
+   if($_ARCHON->db->VersionTDS){
+      putenv("TDSVER={$_ARCHON->db->VersionTDS}");
+   } else {
+      putenv("TDSVER=70");
+   }
 
    ini_set("mssql.textsize", 2147483647);
    ini_set("mssql.textlimit", 2147483647);

--- a/_dev/resources/rm_duplicate_phrases.php
+++ b/_dev/resources/rm_duplicate_phrases.php
@@ -26,7 +26,11 @@ else if(!$_ARCHON->db->Login)
 if($_ARCHON->db->ServerType == 'MSSQL')
 {
    // these are necessary to prevent freetds from truncating large fields
-   putenv("TDSVER=70");
+   if($_ARCHON->db->VersionTDS){
+      putenv("TDSVER={$_ARCHON->db->VersionTDS}");
+   } else {
+      putenv("TDSVER=70");
+   }
 
    ini_set("mssql.textsize", 2147483647);
    ini_set("mssql.textlimit", 2147483647);

--- a/_dev/test/fixsort.php
+++ b/_dev/test/fixsort.php
@@ -59,7 +59,11 @@ if (!$_ARCHON->db->ServerType)
 if ($_ARCHON->db->ServerType == 'MSSQL')
 {
    // these are necessary to prevent freetds from truncating large fields
-   putenv("TDSVER=70");
+   if($_ARCHON->db->VersionTDS){
+      putenv("TDSVER={$_ARCHON->db->VersionTDS}");
+   } else {
+      putenv("TDSVER=70");
+   }
 
    ini_set("mssql.textsize", 2147483647);
    ini_set("mssql.textlimit", 2147483647);

--- a/common.inc.php
+++ b/common.inc.php
@@ -333,6 +333,14 @@ function encode($String, $Encoding)
       return $String;
    }
 
+   //test encoding and convert to utf-8 from latin-1 as needed
+   //(needed if the server does not provide utf-8 encoded characters as expected)
+   $testString = $String;
+   $testSpecialString = htmlspecialchars($testString, ENT_QUOTES, 'UTF-8');
+   if(!$testSpecialString && $testString){
+      $String = encoding_convert_encoding($testString,"UTF-8","ISO-8859-1");
+   }
+
    if($Encoding == ENCODE_HTML || $Encoding == ENCODE_HTMLTHENJAVASCRIPT)
    {
       //ENT_NOQUOTES?

--- a/configblank.inc.php
+++ b/configblank.inc.php
@@ -146,7 +146,39 @@
 
 
 
+  // ********************************************
+   // * $_ARCHON->db->VersionTDS                        *
+   // ********************************************
+   //
+   //   - Explanation:
+   //       Enter the TDS version in use.
+   //   - If nothing is entered, Archon will default
+   //       to 70.
+   //
+
+  // $_ARCHON->db->VersionTDS = '70';
+
+
 // ***********************************************
+// * Database Encoding Conversion Settings       *
+// ***********************************************
+// Only used for MSSQL servers.
+//
+// Set to false to have the php convert from
+// Latin-1 to UTF-8 (previous behavior in Archon).
+//
+// Set to true to turn this conversion off if
+// the database is already in UTF-8 or if the
+// text is getting converted elsewhere already.
+//
+// Note: If you have trouble with Archon converting
+// special characters to multiple other characters
+// you may want to try setting this to true to 
+// see if double encoding is the culprit.
+
+   //$_ARCHON->config->DatabaseEncodingUTF8=false;
+
+//  ***********************************************
 // * Google Analytics Configuration              *
 // ***********************************************
 

--- a/packages/collections/pub/findingaid.php
+++ b/packages/collections/pub/findingaid.php
@@ -10,7 +10,7 @@ isset($_ARCHON) or die();
 
 @set_time_limit(60);
 
-if(is_int($_REQUEST['rootcontentid'])){
+if(is_numeric($_REQUEST['rootcontentid'])){
    $in_RootContentID = $_REQUEST['rootcontentid'];
 } else{
    $in_RootContentID = 0;

--- a/packages/collections/pub/findingaid.php
+++ b/packages/collections/pub/findingaid.php
@@ -10,7 +10,12 @@ isset($_ARCHON) or die();
 
 @set_time_limit(60);
 
-$in_RootContentID = $_REQUEST['rootcontentid'] ? $_REQUEST['rootcontentid'] : 0;
+if(is_int($_REQUEST['rootcontentid'])){
+   $in_RootContentID = $_REQUEST['rootcontentid'];
+} else{
+   $in_RootContentID = 0;
+}
+
 
 // Load the collection and all of its items (pre-processed)
 // into one object

--- a/packages/core/lib/aobject.inc.php
+++ b/packages/core/lib/aobject.inc.php
@@ -53,7 +53,7 @@ abstract class AObject
 
       $String = $this->$Variable;
 
-      if($_ARCHON->db->ServerType == 'MSSQL')
+      if($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8)
       {
          $String = encoding_convert_encoding($String, 'UTF-8', 'ISO-8859-1');
       }

--- a/packages/core/lib/archon.inc.php
+++ b/packages/core/lib/archon.inc.php
@@ -751,9 +751,6 @@ abstract class Core_Archon
          return;
       }
 
-      // Sanitize for XSS.
-      $Error = htmlspecialchars($Error);
-
       $this->Error = $this->Error ? "{$this->Error}; $Error" : $Error;
    }
 
@@ -3792,7 +3789,7 @@ abstract class Core_Archon
                {
                   $arrTypes[] = 'text';
 
-                  if($_ARCHON->db->ServerType == 'MSSQL')
+                  if($_ARCHON->db->ServerType == 'MSSQL' AND !$_ARCHON->config->DatabaseEncodingUTF8)
                   {
                      $Object->$varName = encoding_convert_encoding($Object->$varName, 'ISO-8859-1');
                   }

--- a/packages/core/lib/archonobject.inc.php
+++ b/packages/core/lib/archonobject.inc.php
@@ -104,7 +104,7 @@ abstract class ArchonObject
 
       $String = $this->$Variable;
 
-      if($_ARCHON->db->ServerType == 'MSSQL')
+      if($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8)
       {
          $String = encoding_convert_encoding($String, 'UTF-8', 'ISO-8859-1');
       }

--- a/packages/core/templates/default/accession-list.inc.php
+++ b/packages/core/templates/default/accession-list.inc.php
@@ -74,7 +74,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
                  //Locations
 					RemoveBad($arrAccessionbatch);
 					$arrAccessionbatch = objectToArray($arrAccessionbatch); 
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrAccessionbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrAccessionbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
                     echo $_ARCHON->bbcode_to_html(json_encode($arrAccessionbatch));
        }
        else

--- a/packages/core/templates/default/classification-list.inc.php
+++ b/packages/core/templates/default/classification-list.inc.php
@@ -16,7 +16,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 				exit ("No matching record(s) found for batch_start=".$_REQUEST['batch_start']);
 			}		
         	$arrClassificationbatch = objectToArray($arrClassificationbatch); 
-			if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrClassificationbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+			if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrClassificationbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 
 			echo json_encode($arrClassificationbatch);
 			}

--- a/packages/core/templates/default/collcontent-list.inc.php
+++ b/packages/core/templates/default/collcontent-list.inc.php
@@ -42,7 +42,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
                 }
 				clean_up($arrout);
 				$arrout = objectToArray($arrout); 
-				if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrout, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+				if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrout, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 				echo  $_ARCHON->bbcode_to_html(json_encode($arrout[0]));  // at some point, the object was nested with first element of a parent array, so don't encod the second, null object.-++----
             }
             else

--- a/packages/core/templates/default/collection-list.inc.php
+++ b/packages/core/templates/default/collection-list.inc.php
@@ -69,7 +69,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
         }
 		$arrCollectionbatch = Normalize($arrCollectionbatch);
 		$arrCollectionbatch = objectToArray($arrCollectionbatch); 		
-		if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrCollectionbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+		if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrCollectionbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 		echo $_ARCHON->bbcode_to_html(json_encode(($arrCollectionbatch)));
         }
         else

--- a/packages/core/templates/default/creators-list.inc.php
+++ b/packages/core/templates/default/creators-list.inc.php
@@ -18,7 +18,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
             array_walk($arrCreators, 'GetRelatedCreators');
 			array_walk($arrCreators,'Normalize');
 			$arrCreators = objectToArray($arrCreators);
-			if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrCreators, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode	
+			if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrCreators, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode	
 			echo ($_ARCHON->bbcode_to_html(json_encode($arrCreators)));
         }
         else

--- a/packages/core/templates/default/digitalcontent-list.inc.php
+++ b/packages/core/templates/default/digitalcontent-list.inc.php
@@ -68,7 +68,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
             }
 					Normalize($arrDigitalContentbatch);
 					$arrDigitalContentbatch = objectToArray($arrDigitalContentbatch); 
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrDigitalContentbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrDigitalContentbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
                     echo $_ARCHON->bbcode_to_html(json_encode($arrDigitalContentbatch));
         }else{
 			header('HTTP/1.0 400 Bad Request');

--- a/packages/core/templates/default/digitalfile-list.inc.php
+++ b/packages/core/templates/default/digitalfile-list.inc.php
@@ -19,7 +19,7 @@ $session= $_SERVER['HTTP_SESSION'];
 				}
 	 	array_walk($arrDigitalContentFiles, 'Normalize');
 	 	$arrDigitalContentFiles = objectToArray($arrDigitalContentFiles); 
-		if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrDigitalContentFiles, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+		if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrDigitalContentFiles, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
         echo json_encode(array_values($arrDigitalContentFiles));
 		
         }else{

--- a/packages/core/templates/default/enum-list.inc.php
+++ b/packages/core/templates/default/enum-list.inc.php
@@ -20,7 +20,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'Normalize');
                     array_walk($arrEnumbatch, 'RemoveCountries');
                     $arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
             		       	
@@ -30,7 +30,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'Normalize');
                     array_walk($arrEnumbatch, 'RemoveCreators');
                     $arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
             	
@@ -40,7 +40,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					$arrEnumbatch = array_slice($arrEnum,$start-1,100,true);
 					array_walk($arrEnumbatch, 'Normalize');
 					$arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break; 
 		
@@ -51,7 +51,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'Normalize');
                     array_walk($arrEnumbatch, 'RemoveProcessingPriorities');
                     $arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
 		
@@ -62,7 +62,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'Normalize');
                     array_walk($arrEnumbatch, 'RemoveFileTypes');
                     $arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
    
@@ -72,7 +72,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					$arrEnumbatch = array_slice($arrEnum,$start-1,100,true);
 					array_walk($arrEnumbatch, 'Normalize');
 					$arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break; 
         	        
@@ -83,7 +83,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'NormalizeArray');
 					//array_walk($arrEnumbatch, 'RemoveContainerTypes');
 					$arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break; 
 					
@@ -98,7 +98,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					array_walk($arrEnumbatch, 'Normalize');
                     array_walk($arrEnumbatch, 'RemoveUserGroups');
                     $arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
 					
@@ -108,7 +108,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 					$arrEnumbatch = array_slice($arrEnum,$start-1,100,true);
 					array_walk($arrEnumbatch, 'Normalize');
 					$arrEnumbatch = objectToArray($arrEnumbatch);	
-					if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+					if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrEnumbatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 					echo (empty($arrEnumbatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrEnumbatch));
                 	break;
         

--- a/packages/core/templates/default/repository-list.inc.php
+++ b/packages/core/templates/default/repository-list.inc.php
@@ -15,7 +15,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 		$arrRepBatch = array_slice($arrRep,$start-1,100,true);
 		$arrRepBatch = objectToArray($arrRepBatch);
 		array_walk ($arrRepBatch, 'Normalize');
-		if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrRepBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+		if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrRepBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 		echo (empty($arrRepBatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrRepBatch));
   	} 
     else {

--- a/packages/core/templates/default/subject-list.inc.php
+++ b/packages/core/templates/default/subject-list.inc.php
@@ -14,7 +14,7 @@ if ($_ARCHON->Security->Session->verifysession($session)){
 		$arrSubjBatch = array_slice($arrSubj,$start-1,100,true);
 		array_walk($arrSubjBatch, 'Normalize');	  //works recursively, but only objects
 		$arrSubjBatch = objectToArray($arrSubjBatch); 
-		if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrSubjBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode		
+		if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrSubjBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode		
 		echo (empty($arrSubjBatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : $_ARCHON->bbcode_to_html(json_encode($arrSubjBatch)));
     } 
     else {

--- a/packages/core/templates/default/user-list.inc.php
+++ b/packages/core/templates/default/user-list.inc.php
@@ -15,7 +15,7 @@ if ($_ARCHON->Security->Session->verifysession($session))
 		$arrUser = $_ARCHON->getAllUsers();
 		$arrUserBatch = array_slice(Normalize($arrUser),$start-1,100,true);
 		$arrUserBatch = objectToArray($arrUserBatch);	
-		if ($_ARCHON->db->ServerType == 'MSSQL') {array_walk_recursive($arrUserBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
+		if ($_ARCHON->db->ServerType == 'MSSQL'AND !$_ARCHON->config->DatabaseEncodingUTF8) {array_walk_recursive($arrUserBatch, 'myutf8_encode');}  //fix unicode for MSSQL migrations; function will incorrectly transform mysql unicode
 		echo (empty($arrUserBatch) ? "No matching record(s) found for batch_start=" . $_REQUEST['batch_start'] : json_encode($arrUserBatch));
  
 	} 

--- a/start.inc.php
+++ b/start.inc.php
@@ -57,7 +57,11 @@ elseif(!$_ARCHON->db->Login)
 if($_ARCHON->db->ServerType == 'MSSQL')
 {
    // these are necessary to prevent freetds from truncating large fields
-   putenv("TDSVER=70");
+   if($_ARCHON->db->VersionTDS){
+      putenv("TDSVER={$_ARCHON->db->VersionTDS}");
+   } else {
+      putenv("TDSVER=70");
+   }
 
    ini_set("mssql.textsize", 2147483647);
    ini_set("mssql.textlimit", 2147483647);

--- a/themes/ala_redo/pdfsearch.inc.php
+++ b/themes/ala_redo/pdfsearch.inc.php
@@ -2,10 +2,10 @@
 isset($_ARCHON) or die();
 ?>
 <div id='themeindex' class='bground'>
-   <h1><label for="q">PDF/Deep Search</label></h1>
+  <h1><label for="q">PDF/Deep Search</label></h1>
    <div id='pdfinput'>
-      <form name="form1" action="http://www.google.com/search" class="search">
-         <input type="hidden" name="hq" value="inurl:archives.library.illinois.edu/alasfa" />
+      <form name="form1" action="https://www.google.com/search" class="search">
+         <input type="hidden" name="hq" value="site:files.archon.library.illinois.edu/alasfa/ OR site:archives.library.illinois.edu/alasfa/" />
          <input type="hidden" name="safe" value="off" />
          <input type="hidden" name="filter" value="0" />
          <input id="q" type="text" size="25" name="q" class="searchinput" style='border:solid 1px #ddd'>

--- a/themes/library_web/pdfsearch.inc.php
+++ b/themes/library_web/pdfsearch.inc.php
@@ -11,8 +11,8 @@ isset($_ARCHON) or die();
 <div id='pdfsearchbox' class="bground">
 <h2 style='margin-top:.1em'><label for="q">PDF/Deep Search</label></h2>
 <div style='text-align:center'>				
-    <form name="form1" action="http://www.google.com/search" class="search">
-    <input type="hidden" name="hq" value="inurl:archives.library.illinois.edu/uasfa" />
+    <form name="form1" action="https://www.google.com/search" class="search">
+    <input type="hidden" name="hq" value="site:files.archon.library.illinois.edu/uasfa/ OR site:archives.library.illinois.edu/uasfa/" />
     <input type="hidden" name="safe" value="off" />
     <input type="hidden" name="filter" value="0" />
 	<input id="q" type="text" size="25" name="q" class="searchinput" style='border:solid 1px #ddd'>


### PR DESCRIPTION
This code supports the use of UTF-8 encoding in junction with an MSSQL database (MSSQL added UTF-8 support in 2019). An unrelated SQL injection vulnerability in the finding aid is also addressed.  

There should be no change in functionality for those using a MySQL database or an older MSSQL database. The config file optionally allows one to turn on MSSQL UTF-8 support, and optionally specify a different version of TDS (a version that is higher than that of Archon's default is required for an MSSQL database that supports UTF-8).

Please note, the install-mssql.sql files have not been updated to support MSSQL with UTF-8 encoding. The code in this pull request assumes the MSSQL database migration work to support UTF-8 has been done independently.